### PR TITLE
rename built image to cloud-controller-manager

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -7,7 +7,7 @@ cloud-provider-aws:
         preprocess: 'inject-commit-hash'
       publish:
         dockerimages:
-          cloud-provider-aws:
+          cloud-controller-manager:
             registry: 'gcr-readwrite'
             image: 'eu.gcr.io/gardener-project/kubernetes/cloud-provider-aws'
             dockerfile: 'Dockerfile'


### PR DESCRIPTION
In contrast to other cloud-controller-managers the image has the logical name `cloud-provider-aws` which leads to issues when mapping the image later on in our own landscapes.

This change adjusts the logic name of the image created here to be in sync with the one defined in github.com/gardener/gardener-extension-provider-aws's image.yaml.

The other, simple, fix would be to change the logical name in the images.yaml to be identical to what we use in our landscape.

